### PR TITLE
chore: make `@prisma/client` a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,10 @@
     "typescript": "4.8.2"
   },
   "dependencies": {
-    "@prisma/client": "^4.2.1",
     "fastify-plugin": "^4.2.0"
+  },
+  "peerDependencies": {
+    "@prisma/client": "2.x || 3.9.x || 4.x"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
closes: #21